### PR TITLE
SC-6011 Remove use of `::notice::` to avoid polution of results

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,22 +91,23 @@ runs:
        
         echo "::group::Action outputs" 
         echo "SONAR_HOST_URL=${SONAR_HOST_URL}" >> $GITHUB_ENV
-        echo "::notice::'SONAR_HOST_URL' enviroment variable set to '${SONAR_HOST_URL}'"
 
         SONAR_SCANNER_DIR=$(realpath "${SONAR_SCANNER_DIR}")
         echo "${SONAR_SCANNER_DIR}" >> $GITHUB_PATH
-        echo "::notice::'${SONAR_SCANNER_DIR}' added to the path"
 
         SONAR_SCANNER_BIN=$(realpath "${SONAR_SCANNER_BIN}")
         echo "sonar-scanner-binary=${SONAR_SCANNER_BIN}" >> $GITHUB_OUTPUT
-        echo "::notice::'sonar-scanner-binary' output set to '${SONAR_SCANNER_BIN}'"
         
         BUILD_WRAPPER_DIR=$(realpath "${BUILD_WRAPPER_DIR}")
         echo "${BUILD_WRAPPER_DIR}" >> $GITHUB_PATH
-        echo "::notice::'${BUILD_WRAPPER_DIR}' added to the path"
 
         BUILD_WRAPPER_BIN=$(realpath "${BUILD_WRAPPER_BIN}")
         echo "build-wrapper-binary=${BUILD_WRAPPER_BIN}" >> $GITHUB_OUTPUT
-        echo "::notice::'build-wrapper-binary' output set to '${BUILD_WRAPPER_BIN}'"
-        echo "::endgroup::"
+
+        echo "Action outputs:"
+        echo " * '${SONAR_SCANNER_DIR}' added to the path"
+        echo " * 'sonar-scanner-binary' output set to '${SONAR_SCANNER_BIN}'"
+        echo " * 'SONAR_HOST_URL' enviroment variable set to '${SONAR_HOST_URL}'"
+        echo " * '${BUILD_WRAPPER_DIR}' added to the path"
+        echo " * 'build-wrapper-binary' output set to '${BUILD_WRAPPER_BIN}'"
 

--- a/action.yml
+++ b/action.yml
@@ -88,23 +88,25 @@ runs:
               ;;
           esac
         }  
-        
+       
+        echo "::group::Action outputs" 
         echo "SONAR_HOST_URL=${SONAR_HOST_URL}" >> $GITHUB_ENV
-        echo "::notice:: 'SONAR_HOST_URL' enviroment variable set to '${SONAR_HOST_URL}'"
+        echo "::notice::'SONAR_HOST_URL' enviroment variable set to '${SONAR_HOST_URL}'"
 
         SONAR_SCANNER_DIR=$(realpath "${SONAR_SCANNER_DIR}")
         echo "${SONAR_SCANNER_DIR}" >> $GITHUB_PATH
-        echo "::notice:: '${SONAR_SCANNER_DIR}' added to the path"
+        echo "::notice::'${SONAR_SCANNER_DIR}' added to the path"
 
         SONAR_SCANNER_BIN=$(realpath "${SONAR_SCANNER_BIN}")
         echo "sonar-scanner-binary=${SONAR_SCANNER_BIN}" >> $GITHUB_OUTPUT
-        echo "::notice:: 'sonar-scanner-binary' output set to '${SONAR_SCANNER_BIN}'"
+        echo "::notice::'sonar-scanner-binary' output set to '${SONAR_SCANNER_BIN}'"
         
         BUILD_WRAPPER_DIR=$(realpath "${BUILD_WRAPPER_DIR}")
         echo "${BUILD_WRAPPER_DIR}" >> $GITHUB_PATH
-        echo "::notice:: '${BUILD_WRAPPER_DIR}' added to the path"
+        echo "::notice::'${BUILD_WRAPPER_DIR}' added to the path"
 
         BUILD_WRAPPER_BIN=$(realpath "${BUILD_WRAPPER_BIN}")
         echo "build-wrapper-binary=${BUILD_WRAPPER_BIN}" >> $GITHUB_OUTPUT
-        echo "::notice:: 'build-wrapper-binary' output set to '${BUILD_WRAPPER_BIN}'"
+        echo "::notice::'build-wrapper-binary' output set to '${BUILD_WRAPPER_BIN}'"
+        echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -91,23 +91,21 @@ runs:
        
         echo "::group::Action outputs" 
         echo "SONAR_HOST_URL=${SONAR_HOST_URL}" >> $GITHUB_ENV
+        echo "'SONAR_HOST_URL' enviroment variable set to '${SONAR_HOST_URL}'"
 
         SONAR_SCANNER_DIR=$(realpath "${SONAR_SCANNER_DIR}")
         echo "${SONAR_SCANNER_DIR}" >> $GITHUB_PATH
+        echo "'${SONAR_SCANNER_DIR}' added to the path"
 
         SONAR_SCANNER_BIN=$(realpath "${SONAR_SCANNER_BIN}")
         echo "sonar-scanner-binary=${SONAR_SCANNER_BIN}" >> $GITHUB_OUTPUT
+        echo "'sonar-scanner-binary' output set to '${SONAR_SCANNER_BIN}'"
         
         BUILD_WRAPPER_DIR=$(realpath "${BUILD_WRAPPER_DIR}")
         echo "${BUILD_WRAPPER_DIR}" >> $GITHUB_PATH
+        echo "'${BUILD_WRAPPER_DIR}' added to the path"
 
         BUILD_WRAPPER_BIN=$(realpath "${BUILD_WRAPPER_BIN}")
         echo "build-wrapper-binary=${BUILD_WRAPPER_BIN}" >> $GITHUB_OUTPUT
-
-        echo "Action outputs:"
-        echo " * '${SONAR_SCANNER_DIR}' added to the path"
-        echo " * 'sonar-scanner-binary' output set to '${SONAR_SCANNER_BIN}'"
-        echo " * 'SONAR_HOST_URL' enviroment variable set to '${SONAR_HOST_URL}'"
-        echo " * '${BUILD_WRAPPER_DIR}' added to the path"
-        echo " * 'build-wrapper-binary' output set to '${BUILD_WRAPPER_BIN}'"
+        echo "'build-wrapper-binary' output set to '${BUILD_WRAPPER_BIN}'"
 


### PR DESCRIPTION
Test showed that grouping of messages does not address the message pollution. Changing them to normal output.
