### PR TITLE
SC-6042 Clean up logs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+List of checkpoint to verify/do before merging a PR.
+
+### Dev checklist
+
+* [ ] Write/update tests
+* [ ] Functional validation
+* [ ] Public documentation update
+* [ ] Private documentation update
+* [ ] Clean commits (should start with a ticket number, clear message, no fixup, wip)
+* [ ] Maximize code coverage as much as possible
+
+---
+
+### Reviewer checklist
+
+* [ ] Code review
+* [ ] Functional validation
+* [ ] Check commits are clean
+
+---
+
+### Steps to validate this PR
+
+Fill-in how you performed the validation, and how the reviewer can replicate it:
+* [ ] 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,7 +275,7 @@ jobs:
           grep "=== Script failed ===" output
 
   output-test:
-    name: Action outputs
+    name: Test action outputs
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -286,8 +286,8 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Install sonar-scanner
-        id: install-sonar-scanner
+      - name: Run SonarCloud C/C++ action
+        id: run-action
         uses: ./
         with:
           cache-binaries: ${{ matrix.cache }}
@@ -304,7 +304,7 @@ jobs:
       - name: sonar-scanner-binary output is correct
         shell: bash
         env:
-          BINARY: ${{ steps.install-sonar-scanner.outputs.sonar-scanner-binary }}
+          BINARY: ${{ steps.run-action.outputs.sonar-scanner-binary }}
         run: |
           "$BINARY" --help | grep "INFO: usage: sonar-scanner "
 
@@ -331,6 +331,6 @@ jobs:
       - name: build-wrapper-binary output is correct
         shell: bash
         env:
-          BINARY: ${{ steps.install-sonar-scanner.outputs.build-wrapper-binary }}
+          BINARY: ${{ steps.run-action.outputs.build-wrapper-binary }}
         run: |
           ("$BINARY" || true) | grep "build-wrapper, version "

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,6 @@ outputs:
     description: "Absolute path to build-wrapper binary."
     value: ${{ steps.setup-outputs.outputs.build-wrapper-binary }}
 
-
 runs:
   using: "composite"
   steps:

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -54,9 +54,11 @@ decompress() {
 
 ####################################################################################
 
+echo "::group::Download ${DOWNLOAD_URL}"
 parse_arguments $@
 download
 if [ "$VERIFY_CORRECTNESS" = true ]; then
   verify_download_correctness
 fi
 decompress
+echo "::endgroup::"


### PR DESCRIPTION
How to verify:
* View log output of `Run SonarCloud C/C++ action step), e.g. here: https://github.com/SonarSource/sonarcloud-github-c-cpp-addition/actions/runs/3394190939/jobs/5642438054
* The logs should be nicely grouped (e.g. download script output should be under one group)